### PR TITLE
Tiktoken Defaults Upload for 0.9.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-upload_channels:
-  - sfe1ed40
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d02a5ca6a938e0490e1ff957bc48c8b078c88cb83977be1625b1fd8aac792c5d
 
 build:
-  number: 1
+  number: 0
   skip: True  # [py<39]
   script:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml


### PR DESCRIPTION
## ☆ tiktoken 0.9.0 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8310) 
[Upstream](https://github.com/openai/tiktoken)

### Changes
* Reset build number to 0
* Removed abs.yaml file
